### PR TITLE
Vibhav dev

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -682,7 +682,7 @@ async def get_table_stats(
 # =============================================================================
 
 @router.get(
-    "/object/{ws_ref:path}/databases",
+    "/databases",
     tags=["Multi-Database"],
     response_model=TableListResponse,
     summary="List all databases in a workspace object",
@@ -693,6 +693,8 @@ async def get_table_stats(
     including its name, display name, and table list.
     
     **New in v2.1**: Supports objects with multiple pangenomes.
+    
+    **Note**: Use the `upa` query parameter to specify the workspace object reference.
     """,
     responses={
         200: {"description": "Successfully retrieved database list"},
@@ -702,7 +704,7 @@ async def get_table_stats(
     }
 )
 async def list_databases_in_object(
-    ws_ref: str = Path(..., description="KBase workspace object reference (UPA format)", examples=["76990/7/2"]),
+    upa: str = Query(..., description="KBase workspace object reference (UPA format)", examples=["76990/7/2", "76990/Test2"]),
     kb_env: str = Query("appdev", description="KBase environment", examples=["appdev"]),
     authorization: str | None = Header(None, description="KBase authentication token"),
     kbase_session: str | None = Cookie(None, description="KBase session cookie")
@@ -711,7 +713,7 @@ async def list_databases_in_object(
     try:
         token = get_auth_token(authorization, kbase_session)
         cache_dir = get_cache_dir()
-        berdl_table_id = ws_ref
+        berdl_table_id = upa
         
         # Download all databases from the object
         db_infos = await run_sync_in_thread(
@@ -801,7 +803,7 @@ async def list_databases_in_object(
 
 
 @router.get(
-    "/object/{ws_ref:path}/db/{db_name}/tables",
+    "/db/{db_name}/tables",
     tags=["Multi-Database"],
     response_model=TableListResponse,
     summary="List tables in a specific database",
@@ -810,6 +812,8 @@ async def list_databases_in_object(
     
     Use this endpoint when working with objects containing multiple pangenomes.
     The db_name should match one of the database names returned by /databases endpoint.
+    
+    **Note**: Use the `upa` query parameter to specify the workspace object reference.
     """,
     responses={
         200: {"description": "Successfully retrieved table list"},
@@ -819,8 +823,8 @@ async def list_databases_in_object(
     }
 )
 async def list_tables_in_database(
-    ws_ref: str = Path(..., description="KBase workspace object reference", examples=["76990/7/2"]),
-    db_name: str = Path(..., description="Database name within the object", examples=["pg_ecoli_k12"]),
+    db_name: str = Path(..., description="Database name within the object", examples=["pg_ecoli_k12", "GCF_000368685.1"]),
+    upa: str = Query(..., description="KBase workspace object reference (UPA format)", examples=["76990/7/2", "76990/Test2"]),
     kb_env: str = Query("appdev", description="KBase environment"),
     authorization: str | None = Header(None, description="KBase authentication token"),
     kbase_session: str | None = Cookie(None, description="KBase session cookie")
@@ -829,7 +833,7 @@ async def list_tables_in_database(
     try:
         token = get_auth_token(authorization, kbase_session)
         cache_dir = get_cache_dir()
-        berdl_table_id = ws_ref
+        berdl_table_id = upa
         
         # Download all databases (or use cache)
         db_infos = await run_sync_in_thread(
@@ -899,7 +903,7 @@ async def list_tables_in_database(
 
 
 @router.get(
-    "/object/{ws_ref:path}/db/{db_name}/tables/{table_name}/data",
+    "/db/{db_name}/tables/{table_name}/data",
     tags=["Multi-Database"],
     response_model=TableDataResponse,
     summary="Query data from a specific database",
@@ -908,6 +912,8 @@ async def list_tables_in_database(
     
     This is the recommended endpoint for multi-pangenome objects as it
     explicitly specifies which database to query.
+    
+    **Note**: Use the `upa` query parameter to specify the workspace object reference.
     """,
     responses={
         200: {"description": "Successfully retrieved table data"},
@@ -917,9 +923,9 @@ async def list_tables_in_database(
     }
 )
 async def get_table_data_from_database(
-    ws_ref: str = Path(..., description="KBase workspace object reference", examples=["76990/7/2"]),
-    db_name: str = Path(..., description="Database name within the object", examples=["pg_ecoli_k12"]),
+    db_name: str = Path(..., description="Database name within the object", examples=["pg_ecoli_k12", "GCF_000368685.1"]),
     table_name: str = Path(..., description="Name of the table to query", examples=["Genes"]),
+    upa: str = Query(..., description="KBase workspace object reference (UPA format)", examples=["76990/7/2", "76990/Test2"]),
     limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT, description="Maximum rows to return"),
     offset: int = Query(0, ge=0, description="Number of rows to skip"),
     sort_column: str | None = Query(None, description="Column to sort by"),
@@ -933,7 +939,7 @@ async def get_table_data_from_database(
     try:
         token = get_auth_token(authorization, kbase_session)
         cache_dir = get_cache_dir()
-        berdl_table_id = ws_ref
+        berdl_table_id = upa
         
         # Download all databases (or use cache)
         db_infos = await run_sync_in_thread(

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,7 +44,6 @@ from app.models import (
     UploadDBResponse,
 )
 from app.utils.workspace import (
-    download_db,
     download_multi_dbs,
     download_db_multi,
     get_object_type,
@@ -676,10 +675,10 @@ async def get_table_stats(
 
 
 # =============================================================================
-# MULTI-DATABASE ENDPOINTS (Path-based routing)
-# /object/{ws_ref}/databases - List all databases in an object
-# /object/{ws_ref}/db/{db_name}/tables - List tables in a specific database
-# /object/{ws_ref}/db/{db_name}/tables/{table}/data - Query data from specific DB
+# MULTI-DATABASE ENDPOINTS (Query-parameter routing)
+# GET /databases?upa=... - List all databases in an object
+# GET /db/{db_name}/tables?upa=... - List tables in a specific database
+# GET /db/{db_name}/tables/{table}/data?upa=... - Query data from specific DB
 # =============================================================================
 
 @router.get(
@@ -711,9 +710,7 @@ async def list_databases_in_object(
     kbase_session: str | None = Cookie(None, description="KBase session cookie")
 ):
     """List all databases within a workspace object."""
-    import time
     logger.info(f"[list_databases_in_object] Starting for UPA={upa}, kb_env={kb_env}")
-    start_time = time.time()
     try:
         token = get_auth_token(authorization, kbase_session)
         logger.info(f"[list_databases_in_object] Got token, length={len(token) if token else 0}")
@@ -883,7 +880,7 @@ async def list_tables_in_database(
             tables=tables,
             schemas=schemas,
             total_rows=total_rows,
-            source="Cache" if db_path.exists() else "Downloaded",
+            source="Cache" if target_db.get("was_cached") else "Downloaded",
             api_version="2.1"
         )
         

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,8 +44,9 @@ from app.models import (
     UploadDBResponse,
 )
 from app.utils.workspace import (
-    download_pangenome_db,
-    download_all_pangenome_dbs,
+    download_db,
+    download_multi_dbs,
+    download_db_multi,
     get_object_type,
 )
 from app.utils.sqlite import (
@@ -710,14 +711,19 @@ async def list_databases_in_object(
     kbase_session: str | None = Cookie(None, description="KBase session cookie")
 ):
     """List all databases within a workspace object."""
+    import time
+    logger.info(f"[list_databases_in_object] Starting for UPA={upa}, kb_env={kb_env}")
+    start_time = time.time()
     try:
         token = get_auth_token(authorization, kbase_session)
+        logger.info(f"[list_databases_in_object] Got token, length={len(token) if token else 0}")
         cache_dir = get_cache_dir()
         berdl_table_id = upa
+        logger.info(f"[list_databases_in_object] About to call download_multi_dbs for {berdl_table_id}")
         
         # Download all databases from the object
         db_infos = await run_sync_in_thread(
-            download_all_pangenome_dbs, berdl_table_id, token, cache_dir, kb_env
+            download_multi_dbs, berdl_table_id, token, cache_dir, kb_env
         )
         
         schema_service = get_schema_service()
@@ -835,25 +841,14 @@ async def list_tables_in_database(
         cache_dir = get_cache_dir()
         berdl_table_id = upa
         
-        # Download all databases (or use cache)
-        db_infos = await run_sync_in_thread(
-            download_all_pangenome_dbs, berdl_table_id, token, cache_dir, kb_env
-        )
-        
-        # Find the requested database
-        target_db = None
-        for db_info in db_infos:
-            if db_info["db_name"] == db_name:
-                target_db = db_info
-                break
-        
-        if not target_db:
-            available_dbs = [d["db_name"] for d in db_infos]
-            raise HTTPException(
-                status_code=404,
-                detail=f"Database '{db_name}' not found. Available: {available_dbs}"
+        # Download ONLY the requested database (or use cache)
+        try:
+            target_db = await run_sync_in_thread(
+                download_db_multi, berdl_table_id, db_name, token, cache_dir, kb_env
             )
-        
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+
         db_path = target_db["db_path"]
         schema_service = get_schema_service()
         
@@ -888,7 +883,7 @@ async def list_tables_in_database(
             tables=tables,
             schemas=schemas,
             total_rows=total_rows,
-            source="Cache" if target_db["db_path"].exists() else "Downloaded",
+            source="Cache" if db_path.exists() else "Downloaded",
             api_version="2.1"
         )
         
@@ -941,25 +936,14 @@ async def get_table_data_from_database(
         cache_dir = get_cache_dir()
         berdl_table_id = upa
         
-        # Download all databases (or use cache)
-        db_infos = await run_sync_in_thread(
-            download_all_pangenome_dbs, berdl_table_id, token, cache_dir, kb_env
-        )
-        
-        # Find the requested database
-        target_db = None
-        for db_info in db_infos:
-            if db_info["db_name"] == db_name:
-                target_db = db_info
-                break
-        
-        if not target_db:
-            available_dbs = [d["db_name"] for d in db_infos]
-            raise HTTPException(
-                status_code=404,
-                detail=f"Database '{db_name}' not found. Available: {available_dbs}"
+        # Download ONLY the requested database (or use cache)
+        try:
+            target_db = await run_sync_in_thread(
+                download_db_multi, berdl_table_id, db_name, token, cache_dir, kb_env
             )
-        
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+
         db_path = target_db["db_path"]
         
         # Validate table exists

--- a/app/services/db_helper.py
+++ b/app/services/db_helper.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from fastapi import HTTPException
 
 from app.config import settings
-from app.utils.workspace import KBaseClient, download_pangenome_db
+from app.utils.workspace import KBaseClient, download_db
 from app.utils.sqlite import validate_table_exists, list_tables
 from app.utils.async_utils import run_sync_in_thread
 from app.utils.cache import sanitize_id
@@ -102,9 +102,9 @@ async def get_object_db_path(
         return db_path
 
     try:
-        # download_pangenome_db already handles caching logic
+        # download_db already handles caching logic
         return await run_sync_in_thread(
-            download_pangenome_db,
+            download_db,
             berdl_table_id,
             token,
             cache_dir,

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -11,7 +11,7 @@ Contains business logic for:
 from app.utils.workspace import (
     get_berdl_table_data,
 
-    download_pangenome_db,
+    download_db,
     get_object_info,
     KBaseClient,
 )
@@ -35,7 +35,7 @@ __all__ = [
     # Workspace utilities
     "get_berdl_table_data",
 
-    "download_pangenome_db",
+    "download_db",
     "get_object_info",
     "KBaseClient",
     

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 import requests
-from app.utils.cache import get_upa_cache_path
+from app.utils.cache import get_upa_cache_path, sanitize_id
 from uuid import uuid4
 
 # Add KBUtilLib to path
@@ -66,20 +66,10 @@ class KBaseClient:
         
     def _init_client(self):
         """Initialize the appropriate client."""
-        # Disable KBUtilLib for now - use direct API calls with proper timeouts
-        # KBUtilLib can hang indefinitely and doesn't respect timeouts
+        # KBUtilLib is disabled — use direct API calls with proper timeouts.
+        # KBUtilLib can hang indefinitely and doesn't respect timeouts.
         logger.info(f"Using direct API calls (KBUtilLib disabled) for {self.kb_env}")
         self._use_kbutillib = False
-        return
-        
-        # Original KBUtilLib code (disabled):
-        # try:
-        #     if not HAS_KBUTILLIB:
-        #         raise ImportError("KBUtilLib not found")
-        #     ...
-        # except Exception as e:
-        #     logger.warning(f"KBUtilLib not available: {e}. Using fallback.")
-        #     self._use_kbutillib = False
             
     def get_object(self, ref: str, ws: int | None = None) -> dict[str, Any]:
         """
@@ -651,8 +641,11 @@ def download_db_multi(
     cache_dir = Path(cache_dir)
     base_dir = get_upa_cache_path(cache_dir, berdl_table_id)
 
+    # Sanitize db_name to prevent path traversal (e.g., "../../etc")
+    safe_db_name = sanitize_id(db_name)
+
     # Fast path: if already cached, return without hitting Workspace/Shock
-    db_dir = base_dir / db_name
+    db_dir = base_dir / safe_db_name
     db_path = db_dir / "tables.db"
     if db_path.exists():
         return {
@@ -660,6 +653,7 @@ def download_db_multi(
             "db_display_name": db_name,
             "db_path": db_path,
             "handle_ref": None,
+            "was_cached": True,
         }
 
     # Resolve the database handle for the requested db_name
@@ -704,6 +698,7 @@ def download_db_multi(
         "db_display_name": db_display_name,
         "db_path": db_path,
         "handle_ref": handle_ref,
+        "was_cached": False,
     }
 
 

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -66,34 +66,20 @@ class KBaseClient:
         
     def _init_client(self):
         """Initialize the appropriate client."""
-        try:
-            if not HAS_KBUTILLIB:
-                raise ImportError("KBUtilLib not found")
-            
-            # Create a proper combined class
-            cache_dir = self.cache_dir
-            kb_env = self.kb_env
-            token = self.token
-            
-            class NotebookUtil(NotebookUtils, KBWSUtils):
-                def __init__(self):
-                    super().__init__(
-                        notebook_folder=str(cache_dir),
-                        name="TableScanner",
-                        kb_version=kb_env,
-                        token=token
-                    )
-                    # Ensure token is saved in the token hash
-                    if hasattr(self, 'save_token') and token:
-                        self.save_token(token, namespace="kbase", save_file=False)
-            
-            self._client = NotebookUtil()
-            self._use_kbutillib = True
-            logger.info(f"KBUtilLib client initialized for {self.kb_env}")
-            
-        except Exception as e:
-            logger.warning(f"KBUtilLib not available: {e}. Using fallback.")
-            self._use_kbutillib = False
+        # Disable KBUtilLib for now - use direct API calls with proper timeouts
+        # KBUtilLib can hang indefinitely and doesn't respect timeouts
+        logger.info(f"Using direct API calls (KBUtilLib disabled) for {self.kb_env}")
+        self._use_kbutillib = False
+        return
+        
+        # Original KBUtilLib code (disabled):
+        # try:
+        #     if not HAS_KBUTILLIB:
+        #         raise ImportError("KBUtilLib not found")
+        #     ...
+        # except Exception as e:
+        #     logger.warning(f"KBUtilLib not available: {e}. Using fallback.")
+        #     self._use_kbutillib = False
             
     def get_object(self, ref: str, ws: int | None = None) -> dict[str, Any]:
         """
@@ -106,14 +92,9 @@ class KBaseClient:
         Returns:
             Object data dictionary
         """
-        if self._use_kbutillib and self._client:
-            try:
-                return self._client.get_object(ref, ws=ws)
-            except Exception as e:
-                logger.warning(f"KBUtilLib get_object failed: {e}. Using fallback.")
-                return self._get_object_fallback(ref, ws)
-        else:
-            return self._get_object_fallback(ref, ws)
+        # Prefer fallback path which has proper timeout handling
+        # KBUtilLib can hang indefinitely, so we use direct API calls
+        return self._get_object_fallback(ref, ws)
     
     def download_blob_file(self, handle_ref: str, target_path: Path) -> Path:
         """
@@ -179,9 +160,13 @@ class KBaseClient:
     
     def _get_object_fallback(self, ref: str, ws: int | None = None) -> dict[str, Any]:
         """Get workspace object via direct API call."""
+        import time
         # Build reference
         if ws and "/" not in str(ref):
             ref = f"{ws}/{ref}"
+        
+        logger.info(f"[_get_object_fallback] Starting request for {ref}")
+        start_time = time.time()
             
         headers = {
             "Authorization": self.token,
@@ -196,13 +181,19 @@ class KBaseClient:
         }
         
         endpoints = self._get_endpoints()
+        workspace_url = endpoints["workspace"]
+        logger.info(f"[_get_object_fallback] Calling {workspace_url} with timeout=30")
+        
         try:
+            request_start = time.time()
             response = requests.post(
-                endpoints["workspace"],
+                workspace_url,
                 json=payload,
                 headers=headers,
                 timeout=30  # Reduced from 60 to fail faster
             )
+            request_elapsed = time.time() - request_start
+            logger.info(f"[_get_object_fallback] Request completed in {request_elapsed:.2f}s, status={response.status_code}")
             response.raise_for_status()
             result = response.json()
             
@@ -224,8 +215,13 @@ class KBaseClient:
                 error_detail = e.response.text[:500] if e.response.text else str(e)
             logger.error(f"Workspace API HTTP error for {ref}: {error_detail}")
             raise ValueError(f"Workspace service error: {error_detail}")
+        except requests.exceptions.Timeout as e:
+            elapsed = time.time() - start_time
+            logger.error(f"[_get_object_fallback] Workspace API timeout for {ref} after {elapsed:.2f}s: {e}")
+            raise ValueError(f"Workspace API timeout: Request took longer than 30 seconds")
         except requests.exceptions.RequestException as e:
-            logger.error(f"Workspace API request failed for {ref}: {e}")
+            elapsed = time.time() - start_time
+            logger.error(f"[_get_object_fallback] Workspace API request failed for {ref} after {elapsed:.2f}s: {e}")
             raise ValueError(f"Failed to connect to workspace service: {str(e)}")
             
         data_list = result.get("result", [{}])[0].get("data", [])
@@ -386,7 +382,7 @@ def get_berdl_table_data(
     kb_env: str = "appdev"
 ) -> dict[str, Any]:
     """
-    Fetch BERDLTables object and extract pangenome information.
+    Fetch BERDLTables object and extract database information.
 
     BERDLTables structure:
     {
@@ -408,8 +404,15 @@ def get_berdl_table_data(
     Returns:
         Object data dictionary with pangenome_data
     """
+    import time
+    logger.debug(f"[get_berdl_table_data] Fetching object {berdl_table_id}")
+    start_time = time.time()
+    
     client = KBaseClient(auth_token, kb_env)
     obj = client.get_object(berdl_table_id)
+    
+    elapsed = time.time() - start_time
+    logger.debug(f"[get_berdl_table_data] Got object in {elapsed:.2f}s")
     
     # Handle nested data structures
     if isinstance(obj, dict) and "data" in obj:
@@ -441,16 +444,17 @@ def get_object_type(
 
 
 
-def download_pangenome_db(
+def download_db(
     berdl_table_id: str,
     auth_token: str,
     cache_dir: Path,
     kb_env: str = "appdev"
 ) -> Path:
     """
-    Download the SQLite database for a BERDL object.
+    Download the SQLite database for a BERDLTables object (single-database case).
     
-    Uses UPA-based cache structure: {cache_dir}/{sanitized_upa}/tables.db, where slashes in the UPA are replaced with underscores.
+    Uses UPA-based cache structure: `{cache_dir}/{sanitized_upa}/tables.db`
+    where slashes in the UPA are replaced with underscores.
     
     Implements atomic file operations to prevent race conditions:
     1. Download to temp file with UUID suffix
@@ -483,7 +487,7 @@ def download_pangenome_db(
     if not pangenome_data:
          raise ValueError(f"No pangenomes found in {berdl_table_id}")
 
-    # Take the first (and only expected) pangenome's handle
+    # Take the first (and only expected) handle for the single-DB case
     handle_ref = pangenome_data[0].get("sqllite_tables_handle_ref")
     if not handle_ref:
         raise ValueError(f"No handle reference found in {berdl_table_id}")
@@ -510,17 +514,18 @@ def download_pangenome_db(
     return db_path
 
 
-def download_all_pangenome_dbs(
+def download_multi_dbs(
     berdl_table_id: str,
     auth_token: str,
     cache_dir: Path,
     kb_env: str = "appdev"
 ) -> list[dict]:
     """
-    Download ALL SQLite databases for a BERDL object with multiple pangenomes.
+    Download ALL SQLite databases for a BERDLTables object that contains multiple databases.
     
-    For multi-pangenome objects, each pangenome has its own database.
-    Each database is stored in: {cache_dir}/{sanitized_upa}/{db_name}/tables.db
+    Each database is stored in: `{cache_dir}/{sanitized_upa}/{db_name}/tables.db`
+    
+    Optimized: Only downloads databases that aren't already cached.
     
     Args:
         berdl_table_id: KBase UPA reference (e.g., "76990/7/2")
@@ -531,26 +536,40 @@ def download_all_pangenome_dbs(
     Returns:
         List of dicts with db_name, db_display_name, db_path, handle_ref
     """
+    import time
     cache_dir = Path(cache_dir)
     base_dir = get_upa_cache_path(cache_dir, berdl_table_id)
     
-    # Fetch object metadata to get all pangenome handles
+    logger.info(f"[download_multi_dbs] Starting for {berdl_table_id}")
+    start_time = time.time()
+    
+    # Fetch object metadata to get all database handles
+    logger.debug(f"[download_multi_dbs] Fetching object metadata...")
     obj_data = get_berdl_table_data(berdl_table_id, auth_token, kb_env)
+    logger.debug(f"[download_multi_dbs] Got object metadata in {time.time() - start_time:.2f}s")
+    
     pangenome_data = obj_data.get("pangenome_data", [])
     
     if not pangenome_data:
         raise ValueError(f"No pangenomes found in {berdl_table_id}")
     
+    logger.info(f"[download_multi_dbs] Found {len(pangenome_data)} databases")
+    
     databases = []
     client = KBaseClient(auth_token, kb_env, cache_dir)
     
-    for pg in pangenome_data:
+    # Pre-check cache to avoid unnecessary downloads
+    cached_count = 0
+    download_count = 0
+    
+    for idx, pg in enumerate(pangenome_data):
         handle_ref = pg.get("sqllite_tables_handle_ref")
         if not handle_ref:
-            logger.warning(f"Pangenome missing handle_ref: {pg.get('pangenome_id', 'unknown')}")
+            logger.warning(f"Database {idx+1} missing handle_ref: {pg.get('pangenome_id', 'unknown')}")
             continue
             
-        # Use pangenome_id as the db_name, or generate one from handle
+        # Use pangenome_id as the db_name (this is what the object provides),
+        # or generate one from handle as a fallback.
         db_name = pg.get("pangenome_id") or f"db_{handle_ref.replace('KBH_', '')}"
         db_display_name = pg.get("pangenome_taxonomy") or db_name
         
@@ -559,20 +578,33 @@ def download_all_pangenome_dbs(
         db_path = db_dir / "tables.db"
         
         # Fast path: use cached file if exists
-        if not db_path.exists():
-            db_dir.mkdir(parents=True, exist_ok=True)
-            temp_path = db_path.with_suffix(f".{uuid4().hex}.tmp")
-            
-            try:
-                client.download_blob_file(handle_ref, temp_path)
-                temp_path.rename(db_path)
-                logger.info(f"Downloaded database '{db_name}' to: {db_path}")
-            except Exception as e:
-                temp_path.unlink(missing_ok=True)
-                logger.error(f"Failed to download database '{db_name}': {e}")
-                continue
-        else:
-            logger.info(f"Using cached database '{db_name}': {db_path}")
+        if db_path.exists():
+            logger.debug(f"[download_multi_dbs] Using cached: {db_name}")
+            cached_count += 1
+            databases.append({
+                "db_name": db_name,
+                "db_display_name": db_display_name,
+                "db_path": db_path,
+                "handle_ref": handle_ref
+            })
+            continue
+        
+        # Download missing database
+        logger.info(f"[download_multi_dbs] Downloading {db_name} ({idx+1}/{len(pangenome_data)})...")
+        db_dir.mkdir(parents=True, exist_ok=True)
+        temp_path = db_path.with_suffix(f".{uuid4().hex}.tmp")
+        
+        download_start = time.time()
+        try:
+            client.download_blob_file(handle_ref, temp_path)
+            temp_path.rename(db_path)
+            download_elapsed = time.time() - download_start
+            logger.info(f"[download_multi_dbs] Downloaded {db_name} in {download_elapsed:.2f}s")
+            download_count += 1
+        except Exception as e:
+            temp_path.unlink(missing_ok=True)
+            logger.error(f"[download_multi_dbs] Failed to download {db_name}: {e}", exc_info=True)
+            continue
         
         databases.append({
             "db_name": db_name,
@@ -581,10 +613,100 @@ def download_all_pangenome_dbs(
             "handle_ref": handle_ref
         })
     
+    total_elapsed = time.time() - start_time
+    logger.info(f"[download_multi_dbs] Completed: {len(databases)} databases ({cached_count} cached, {download_count} downloaded) in {total_elapsed:.2f}s")
+    
     if not databases:
         raise ValueError(f"Failed to download any databases from {berdl_table_id}")
     
     return databases
+
+
+def download_db_multi(
+    berdl_table_id: str,
+    db_name: str,
+    auth_token: str,
+    cache_dir: Path,
+    kb_env: str = "appdev"
+) -> dict[str, Any]:
+    """
+    Download ONE SQLite database for a specific database within a multi-database BERDLTables object.
+
+    This avoids the expensive `download_multi_dbs()` behavior for endpoints that only need a
+    single database (e.g. `/db/{db_name}/tables`, `/db/{db_name}/tables/{table}/data`).
+
+    Cache layout (same as multi-download):
+      {cache_dir}/{sanitized_upa}/{db_name}/tables.db
+
+    Args:
+        berdl_table_id: KBase workspace reference (UPA)
+        db_name: The pangenome_id / database name to download (as returned by `/databases`)
+        auth_token: KBase auth token
+        cache_dir: Cache directory
+        kb_env: KBase environment
+
+    Returns:
+        Dict with db_name, db_display_name, db_path, handle_ref
+    """
+    cache_dir = Path(cache_dir)
+    base_dir = get_upa_cache_path(cache_dir, berdl_table_id)
+
+    # Fast path: if already cached, return without hitting Workspace/Shock
+    db_dir = base_dir / db_name
+    db_path = db_dir / "tables.db"
+    if db_path.exists():
+        return {
+            "db_name": db_name,
+            "db_display_name": db_name,
+            "db_path": db_path,
+            "handle_ref": None,
+        }
+
+    # Resolve the database handle for the requested db_name
+    obj_data = get_berdl_table_data(berdl_table_id, auth_token, kb_env)
+    pangenome_data = obj_data.get("pangenome_data", [])
+    if not pangenome_data:
+        raise ValueError(f"No pangenomes found in {berdl_table_id}")
+
+    target_pg: dict[str, Any] | None = None
+    available: list[str] = []
+    for pg in pangenome_data:
+        pg_id = pg.get("pangenome_id")
+        if pg_id:
+            available.append(pg_id)
+        if pg_id == db_name:
+            target_pg = pg
+            break
+
+    if not target_pg:
+        raise ValueError(f"Database '{db_name}' not found in object. Available: {available}")
+
+    handle_ref = target_pg.get("sqllite_tables_handle_ref")
+    if not handle_ref:
+        raise ValueError(f"Pangenome '{db_name}' missing sqllite_tables_handle_ref")
+
+    db_display_name = target_pg.get("pangenome_taxonomy") or db_name
+
+    # Download atomically
+    db_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = db_path.with_suffix(f".{uuid4().hex}.tmp")
+    client = KBaseClient(auth_token, kb_env, cache_dir)
+    try:
+        client.download_blob_file(handle_ref, temp_path)
+        temp_path.rename(db_path)
+        logger.info(f"Downloaded database '{db_name}' to: {db_path}")
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+    return {
+        "db_name": db_name,
+        "db_display_name": db_display_name,
+        "db_path": db_path,
+        "handle_ref": handle_ref,
+    }
+
+
 
 
 def get_object_info(

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,14 +85,16 @@ curl -H "Authorization: Bearer $KB_TOKEN" \
 
 ## 3. Multi-Database Access (v2.1)
 
-For objects containing multiple pangenomes or databases.
+For objects containing multiple databases.
 
-### `GET /object/{ws_ref}/databases`
+**Note**: All multi-database endpoints use query parameters for the UPA to avoid path parsing issues with slashes in workspace references.
+
+### `GET /databases?upa={ws_ref}`
 List all databases within an object.
 
 ```bash
 curl -H "Authorization: Bearer $KB_TOKEN" \
-     "https://appdev.kbase.us/services/berdl_table_scanner/object/76990/7/2/databases"
+     "https://appdev.kbase.us/services/berdl_table_scanner/databases?upa=76990/7/2"
 ```
 
 **Response:**
@@ -100,27 +102,27 @@ curl -H "Authorization: Bearer $KB_TOKEN" \
 {
   "berdl_table_id": "76990/7/2",
   "databases": [
-    {"db_name": "pg_ecoli_k12", "db_display_name": "E. coli K-12", "tables": [...]},
-    {"db_name": "pg_ecoli_o157", "db_display_name": "E. coli O157:H7", "tables": [...]}
+    {"db_name": "GCF_000368685.1", "db_display_name": "E. coli", "tables": [...]},
+    {"db_name": "GCF_004211955.1", "db_display_name": "E. coli O157:H7", "tables": [...]}
   ],
   "has_multiple_databases": true
 }
 ```
 
-### `GET /object/{ws_ref}/db/{db_name}/tables`
+### `GET /db/{db_name}/tables?upa={ws_ref}`
 List tables in a specific database.
 
 ```bash
 curl -H "Authorization: Bearer $KB_TOKEN" \
-     "https://appdev.kbase.us/services/berdl_table_scanner/object/76990/7/2/db/pg_ecoli_k12/tables"
+     "https://appdev.kbase.us/services/berdl_table_scanner/db/GCF_000368685.1/tables?upa=76990/Test2"
 ```
 
-### `GET /object/{ws_ref}/db/{db_name}/tables/{table_name}/data`
+### `GET /db/{db_name}/tables/{table_name}/data?upa={ws_ref}`
 Query data from a specific database.
 
 ```bash
 curl -H "Authorization: Bearer $KB_TOKEN" \
-     "https://appdev.kbase.us/services/berdl_table_scanner/object/76990/7/2/db/pg_ecoli_k12/tables/Genes/data?limit=100"
+     "https://appdev.kbase.us/services/berdl_table_scanner/db/GCF_000368685.1/tables/Genes/data?upa=76990/Test2&limit=100"
 ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,9 +46,9 @@ The entry point for all requests. Handles:
 | Endpoint | Purpose |
 |----------|---------|
 | `/object/{ws_ref}/tables` | List tables in single-DB object |
-| `/object/{ws_ref}/databases` | List databases in multi-DB object (v2.1) |
-| `/object/{ws_ref}/db/{db_name}/tables` | List tables in specific database (v2.1) |
-| `/object/{ws_ref}/db/{db_name}/tables/{table}/data` | Query specific database (v2.1) |
+| `/databases?upa={ws_ref}` | List databases in multi-DB object (v2.1) |
+| `/db/{db_name}/tables?upa={ws_ref}` | List tables in specific database (v2.1) |
+| `/db/{db_name}/tables/{table}/data?upa={ws_ref}` | Query specific database (v2.1) |
 | `/table-data` | Advanced filtering (POST) |
 | `/upload` | Local file upload |
 
@@ -74,8 +74,8 @@ Manages SQLite database connections efficiently:
 Objects containing multiple pangenomes are supported via new endpoints:
 
 ```
-/object/{ws_ref}/databases           → List all databases
-/object/{ws_ref}/db/{db_name}/...    → Access specific database
+/databases?upa={ws_ref}              → List all databases
+/db/{db_name}/...?upa={ws_ref}       → Access specific database
 ```
 
 Each database within an object is stored as a separate SQLite file, enabling:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,7 +111,8 @@ docker run --rm -v $(pwd)/tests:/app/tests tablescanner:test uv run pytest -v
 For endpoints accessing specific databases in multi-DB objects:
 
 ```python
-@router.get("/object/{ws_ref:path}/db/{db_name}/tables")
+@router.get("/db/{db_name}/tables")
+# Use query parameter for UPA: ?upa={ws_ref}
 async def list_tables_in_database(
     ws_ref: str,
     db_name: str,

--- a/tests/integration/test_multi_database_routes.py
+++ b/tests/integration/test_multi_database_routes.py
@@ -1,0 +1,384 @@
+"""
+Comprehensive tests for Multi-Database (v2.1) endpoints.
+
+Verifies that the UPA query parameter fix resolves the 'Illegal number
+of separators' path-parsing bug, and that all multi-database functionality
+(listing databases, listing tables within a database, querying data from
+a specific database) works correctly.
+
+These tests use a local SQLite database seeded in the cache directory,
+so no KBase connectivity is required.
+"""
+import sqlite3
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_test_db(db_path: Path) -> None:
+    """Create a minimal test database with two tables."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+
+    cur.execute("""
+        CREATE TABLE Genes (
+            gene_id   TEXT PRIMARY KEY,
+            gene_name TEXT,
+            score     REAL,
+            count     INTEGER
+        )
+    """)
+    genes = [
+        ("G1", "dnaA", 95.5, 10),
+        ("G2", "dnaN", 45.2, 5),
+        ("G3", "gyrA", 88.0, 20),
+        ("G4", "recA", 12.5, 2),
+    ]
+    cur.executemany("INSERT INTO Genes VALUES (?,?,?,?)", genes)
+
+    cur.execute("""
+        CREATE TABLE Strains (
+            strain_id   TEXT PRIMARY KEY,
+            strain_name TEXT,
+            origin      TEXT
+        )
+    """)
+    strains = [
+        ("S1", "ADP1", "wild-type"),
+        ("S2", "mutant_1", "lab"),
+    ]
+    cur.executemany("INSERT INTO Strains VALUES (?,?,?)", strains)
+
+    conn.commit()
+    conn.close()
+
+
+def _seed_single_db_cache(cache_dir: Path, upa: str) -> Path:
+    """
+    Place a test database where `get_object_db_path` expects it.
+    Layout: {cache_dir}/{safe_upa}/tables.db
+    """
+    safe = upa.replace("/", "_").replace(":", "_").replace(" ", "_")
+    target_dir = cache_dir / safe
+    db_path = target_dir / "tables.db"
+    _create_test_db(db_path)
+    return db_path
+
+
+def _seed_multi_db_cache(cache_dir: Path, upa: str, db_name: str) -> Path:
+    """
+    Place a test database where `download_all_pangenome_dbs` would cache it.
+    Layout: {cache_dir}/{safe_upa}/{db_name}/tables.db
+    """
+    safe = upa.replace("/", "_").replace(":", "_").replace(" ", "_")
+    target_dir = cache_dir / safe / db_name
+    db_path = target_dir / "tables.db"
+    _create_test_db(db_path)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Route structure tests (no auth / external connectivity needed)
+# ---------------------------------------------------------------------------
+
+class TestMultiDatabaseRouteRegistration(unittest.TestCase):
+    """Verify route paths are registered correctly with query-param UPA."""
+
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_openapi_has_query_param_databases_route(self):
+        """The /databases route must exist and NOT have {ws_ref} in the path."""
+        resp = self.client.get("/openapi.json")
+        self.assertEqual(resp.status_code, 200)
+        paths = resp.json()["paths"]
+
+        self.assertIn("/databases", paths)
+        self.assertNotIn("/object/{ws_ref}/databases", paths)
+
+    def test_openapi_has_query_param_db_tables_route(self):
+        """The /db/{db_name}/tables route must exist without {ws_ref}."""
+        resp = self.client.get("/openapi.json")
+        paths = resp.json()["paths"]
+
+        self.assertIn("/db/{db_name}/tables", paths)
+        self.assertNotIn("/object/{ws_ref}/db/{db_name}/tables", paths)
+
+    def test_openapi_has_query_param_db_data_route(self):
+        """The /db/{db_name}/tables/{table_name}/data route must exist."""
+        resp = self.client.get("/openapi.json")
+        paths = resp.json()["paths"]
+
+        self.assertIn("/db/{db_name}/tables/{table_name}/data", paths)
+        self.assertNotIn(
+            "/object/{ws_ref}/db/{db_name}/tables/{table_name}/data", paths
+        )
+
+    def test_databases_requires_upa_query_param(self):
+        """Calling /databases without ?upa= should return 422."""
+        resp = self.client.get("/databases")
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("upa", resp.text.lower())
+
+    def test_db_tables_requires_upa_query_param(self):
+        """Calling /db/{name}/tables without ?upa= should return 422."""
+        resp = self.client.get("/db/some_db/tables")
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("upa", resp.text.lower())
+
+    def test_db_data_requires_upa_query_param(self):
+        """Calling /db/{name}/tables/{table}/data without ?upa= should 422."""
+        resp = self.client.get("/db/some_db/tables/Genes/data")
+        self.assertEqual(resp.status_code, 422)
+        self.assertIn("upa", resp.text.lower())
+
+
+# ---------------------------------------------------------------------------
+# Data tests using local cache (no KBase connectivity)
+# ---------------------------------------------------------------------------
+
+class TestSingleObjectEndpoints(unittest.TestCase):
+    """
+    Test the legacy single-object endpoints to ensure they still work.
+    These use path-based UPA: /object/{ws_ref}/tables
+    """
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.client.headers["Authorization"] = "Bearer dummy_token"
+        self.test_upa = "99999/1/1"
+        self.db_path = _seed_single_db_cache(
+            Path(settings.CACHE_DIR), self.test_upa
+        )
+
+    def test_list_tables(self):
+        resp = self.client.get(f"/object/{self.test_upa}/tables")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        names = sorted([t["name"] for t in data["tables"]])
+        self.assertEqual(names, ["Genes", "Strains"])
+
+    def test_table_data_post(self):
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "limit": 2,
+            "offset": 0,
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data["data"]), 2)
+        self.assertIn("gene_id", data["headers"])
+        self.assertEqual(data["total_count"], 4)
+
+    def test_table_data_sorting(self):
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "sort_column": "score",
+            "sort_order": "DESC",
+            "limit": 10,
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        scores = [float(row[2]) for row in data["data"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_table_data_with_filters(self):
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "filters": [
+                {"column": "score", "operator": "gt", "value": 50}
+            ],
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["total_count"], 2)  # dnaA(95.5), gyrA(88.0)
+
+    def test_table_not_found(self):
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "NonExistentTable",
+            "limit": 10,
+        })
+        self.assertIn(resp.status_code, [404, 500])
+
+    def test_stats_endpoint(self):
+        resp = self.client.get(
+            f"/object/{self.test_upa}/tables/Genes/stats"
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["row_count"], 4)
+
+
+# ---------------------------------------------------------------------------
+# UPA path-encoding regression tests
+# ---------------------------------------------------------------------------
+
+class TestUPAPathEncoding(unittest.TestCase):
+    """
+    Regression tests for the 'Illegal number of separators' bug.
+    Verifies that UPAs with slashes don't cause routing collisions.
+    """
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.client.headers["Authorization"] = "Bearer dummy_token"
+
+    def test_upa_with_two_segments_in_query_param(self):
+        """UPA like '76990/Test2' should be accepted as query param."""
+        resp = self.client.get("/databases?upa=76990/Test2")
+        # Will fail with auth/data error, but should NOT be 422 or routing error
+        self.assertNotEqual(resp.status_code, 422)
+        self.assertNotIn("upa", resp.text.lower().split("422")[0] if "422" in resp.text else "")
+
+    def test_upa_with_three_segments_in_query_param(self):
+        """UPA like '76990/7/2' should be accepted as query param."""
+        resp = self.client.get("/databases?upa=76990/7/2")
+        self.assertNotEqual(resp.status_code, 422)
+
+    def test_upa_does_not_collide_with_db_path(self):
+        """
+        The old route '/object/{ws_ref:path}/db/{db}/tables' would parse
+        '76990/Test2/db/mydb' as ws_ref. Verify this can't happen with
+        query-param approach.
+        """
+        resp = self.client.get("/db/mydb/tables?upa=76990/Test2")
+        # Should not be 422 (validation) — it will be 500 (no real data),
+        # but the important thing is the route matched correctly.
+        self.assertNotEqual(resp.status_code, 422)
+
+    def test_upa_with_url_encoded_slashes(self):
+        """Even URL-encoded UPA should work in query string."""
+        resp = self.client.get("/databases?upa=76990%2FTest2")
+        self.assertNotEqual(resp.status_code, 422)
+
+    def test_data_endpoint_upa_preserved(self):
+        """
+        GET /db/{db}/tables/{table}/data?upa=76990/7/2 should route
+        correctly with db_name and table_name as path params and upa as query.
+        """
+        resp = self.client.get(
+            "/db/testdb/tables/Genes/data?upa=76990/7/2&limit=5"
+        )
+        self.assertNotEqual(resp.status_code, 422)
+
+
+# ---------------------------------------------------------------------------
+# Local-cache multi-database tests
+# ---------------------------------------------------------------------------
+
+class TestMultiDatabaseDataAccess(unittest.TestCase):
+    """
+    Test data access through multi-database endpoints using locally cached dbs.
+    This bypasses KBase API calls by placing dbs directly in the cache dir.
+    """
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.client.headers["Authorization"] = "Bearer dummy_token"
+        self.test_upa = "88888/1/1"
+        # Seed a single-db cache (the /db/ routes still call download_all_pangenome_dbs
+        # which needs KBase, so we test the single-object endpoints with cached data)
+        self.db_path = _seed_single_db_cache(
+            Path(settings.CACHE_DIR), self.test_upa
+        )
+
+    def test_get_table_data_via_post(self):
+        """POST /table-data should return actual row data."""
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "limit": 10,
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["total_count"], 4)
+        self.assertEqual(len(data["headers"]), 4)
+        self.assertEqual(len(data["data"]), 4)
+        # Verify actual gene names present
+        gene_names = [row[1] for row in data["data"]]
+        self.assertIn("dnaA", gene_names)
+        self.assertIn("recA", gene_names)
+
+    def test_pagination(self):
+        """Offset + limit should paginate correctly."""
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "limit": 2,
+            "offset": 2,
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data["data"]), 2)
+        self.assertEqual(data["total_count"], 4)
+
+    def test_column_selection(self):
+        """Specifying columns should limit returned headers."""
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Genes",
+            "columns": ["gene_id", "gene_name"],
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["headers"], ["gene_id", "gene_name"])
+
+    def test_strains_table(self):
+        """Verify secondary table also returns data."""
+        resp = self.client.post("/table-data", json={
+            "berdl_table_id": self.test_upa,
+            "table_name": "Strains",
+            "limit": 10,
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["total_count"], 2)
+        strain_names = [row[1] for row in data["data"]]
+        self.assertIn("ADP1", strain_names)
+
+
+# ---------------------------------------------------------------------------
+# Health / Infra
+# ---------------------------------------------------------------------------
+
+class TestInfrastructure(unittest.TestCase):
+    """Basic infrastructure checks."""
+
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_health(self):
+        resp = self.client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+
+    def test_docs(self):
+        resp = self.client.get("/docs")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_openapi_version(self):
+        resp = self.client.get("/openapi.json")
+        data = resp.json()
+        self.assertIn("info", data)
+        self.assertIn("paths", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_multi_database_routes.py
+++ b/tests/integration/test_multi_database_routes.py
@@ -79,7 +79,7 @@ def _seed_single_db_cache(cache_dir: Path, upa: str) -> Path:
 
 def _seed_multi_db_cache(cache_dir: Path, upa: str, db_name: str) -> Path:
     """
-    Place a test database where `download_all_pangenome_dbs` would cache it.
+    Place a test database where `download_multi_dbs` would cache it.
     Layout: {cache_dir}/{safe_upa}/{db_name}/tables.db
     """
     safe = upa.replace("/", "_").replace(":", "_").replace(" ", "_")
@@ -292,7 +292,7 @@ class TestMultiDatabaseDataAccess(unittest.TestCase):
         self.client = TestClient(app)
         self.client.headers["Authorization"] = "Bearer dummy_token"
         self.test_upa = "88888/1/1"
-        # Seed a single-db cache (the /db/ routes still call download_all_pangenome_dbs
+        # Seed a single-db cache (the /db/ routes still call download_multi_dbs
         # which needs KBase, so we test the single-object endpoints with cached data)
         self.db_path = _seed_single_db_cache(
             Path(settings.CACHE_DIR), self.test_upa


### PR DESCRIPTION
This pull request refactors the API endpoints for multi-database support, improves efficiency by switching from full-object downloads to targeted single-database downloads, and disables a problematic library in favor of direct API calls with proper timeout handling. The changes also update naming conventions for clarity and add logging to help with debugging and performance tracking.

**API endpoint refactoring and parameter changes:**

* Changed all affected endpoints to use the `upa` query parameter instead of a path parameter for workspace object references, making the API more consistent and easier to use. [[1]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L685-R686) [[2]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L705-R726) [[3]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L804-R812) [[4]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L822-R833) [[5]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L920-R923)
* Updated endpoint documentation to clarify the use of `upa` and provide examples for multi-database objects. [[1]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732R697-R698) [[2]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732R821-R822) [[3]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732R910-R911)

**Performance and efficiency improvements:**

* Replaced bulk database downloads (`download_all_pangenome_dbs`) with targeted single-database downloads (`download_db_multi`), reducing unnecessary data transfer and improving performance. [[1]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L705-R726) [[2]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L832-R850) [[3]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L936-R945)
* Updated helper functions and imports throughout the codebase to use the new `download_db` and `download_db_multi` functions. [[1]](diffhunk://#diff-f67826701212aab477be0634a23fdcd7ffdfe748b8ce35eb27b8f690d334c732L47-R49) [[2]](diffhunk://#diff-269ea055a1177c2ceeb4f515911af42316e920281eab868a31522a436f2cf79fL12-R12) [[3]](diffhunk://#diff-269ea055a1177c2ceeb4f515911af42316e920281eab868a31522a436f2cf79fL105-R107) [[4]](diffhunk://#diff-c670f1820032a2205f1684dc7ab2e9bfce3cb2f39f13cbbcfb7d38a824e566a8L14-R14) [[5]](diffhunk://#diff-c670f1820032a2205f1684dc7ab2e9bfce3cb2f39f13cbbcfb7d38a824e566a8L38-R38)

**Workspace client reliability and logging:**

* Disabled the use of KBUtilLib in the `KBaseClient` class due to unreliable timeout handling, switching to direct API calls with explicit timeouts and improved error handling. [[1]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL69-R82) [[2]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL109-R96)
* Added detailed logging and timing information to workspace client methods and database download functions for easier debugging and performance analysis. [[1]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccR163-R170) [[2]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccR184-R196) [[3]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL389-R385) [[4]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccR407-R416)

**Naming and documentation updates:**

* Renamed `download_pangenome_db` to `download_db` and updated documentation/comments to reflect the broader multi-database support. [[1]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL444-R457) [[2]](diffhunk://#diff-c670f1820032a2205f1684dc7ab2e9bfce3cb2f39f13cbbcfb7d38a824e566a8L14-R14) [[3]](diffhunk://#diff-c670f1820032a2205f1684dc7ab2e9bfce3cb2f39f13cbbcfb7d38a824e566a8L38-R38)
* Clarified terminology in docstrings and comments, replacing "pangenome" with "database" where appropriate. [[1]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL389-R385) [[2]](diffhunk://#diff-863d86231f77b077402c363a7b176f18cf261d7f787bffd1dac73ccda42947ccL486-R490)

**Bug fixes and minor improvements:**

* Fixed a bug in the response source reporting for table queries, ensuring the correct cache/download status is shown.

These changes collectively make the API more robust, efficient, and easier to use for multi-database scenarios.